### PR TITLE
二段階チェックリスト機能を実装

### DIFF
--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -14,6 +14,7 @@ import TemplateButton from "./TemplateButton"
 export default function Checklist() {
   const [items, setItems] = useState<Item[]>([])
   const [showTemplateSelector, setShowTemplateSelector] = useState(true)
+  const [twoStageMode, setTwoStageMode] = useState(false)
 
   // チェックボックスのON/OFF
   const toggleItem = (id: string) => {
@@ -29,11 +30,20 @@ export default function Checklist() {
     setItems(prev => prev.filter(item => item.id !== id))
   }
 
+  // 調達チェックのON/OFF
+  const toggleProcured = (id: string) => {
+    setItems(prev =>
+      prev.map(item =>
+        item.id === id ? { ...item, isProcured: !item.isProcured } : item
+      )
+    )
+  }
+
   // 追加
   const addItem = (text: string) => {
     setItems(prev => [
       ...prev,
-      { id: Date.now().toString(), text, isChecked: false },
+      { id: Date.now().toString(), text, isChecked: false, isProcured: false },
     ])
   }
 
@@ -50,7 +60,8 @@ export default function Checklist() {
   const handleSelectTemplate = (template: Template) => {
     const itemsWithUniqueIds = template.items.map((item, index) => ({
       ...item,
-      id: `${template.id}-${index}-${Date.now()}`
+      id: `${template.id}-${index}-${Date.now()}`,
+      isProcured: false
     }))
     setItems(itemsWithUniqueIds)
     setShowTemplateSelector(false)
@@ -87,6 +98,36 @@ export default function Checklist() {
       {/* タイトル */}
       <h1 className="text-xl font-bold mb-4">もちもちリスト</h1>
 
+      {/* 二段階チェックリスト切り替えボタン */}
+      <div className="mb-4">
+        <button
+          onClick={() => setTwoStageMode(!twoStageMode)}
+          className={`px-4 py-2 rounded font-medium text-sm transition-all ${
+            twoStageMode
+              ? 'bg-dango-green-500 text-white shadow-md hover:bg-dango-green-600'
+              : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+          }`}
+        >
+          {twoStageMode ? '📦🎒 二段階チェックモード ON' : '二段階チェックモード OFF'}
+        </button>
+      </div>
+
+      {/* スクロール追従ラベル */}
+      {twoStageMode && (
+        <div className="sticky top-0 z-10 bg-gray-100/95 backdrop-blur-sm border-b-2 border-gray-300/50 py-3 mb-4 shadow-sm">
+          <div className="flex justify-center gap-8 text-sm font-semibold text-gray-800">
+            <div className="flex items-center gap-1 px-3 py-1 bg-dango-pink-300 rounded-full">
+              <span>📦</span>
+              <span>調達</span>
+            </div>
+            <div className="flex items-center gap-1 px-3 py-1 bg-dango-green-300 rounded-full">
+              <span>🎒</span>
+              <span>カバン</span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* テンプレート選択ボタン */}
       <TemplateButton onNewTemplate={handleNewTemplate} />
 
@@ -102,6 +143,8 @@ export default function Checklist() {
             onToggle={toggleItem}
             onDelete={deleteItem}
             onUpdate={updateItem}
+            onToggleProcured={toggleProcured}
+            twoStageMode={twoStageMode}
           />
         ))}
       </ul>
@@ -113,7 +156,7 @@ export default function Checklist() {
       <ChecklistDropzone onAdd={addItem} />
 
       {/* エクスポート & インポート */}
-      <div className="flex gap-2 mt-4">
+      <div className="flex gap-3 mt-4 justify-center">
         <ChecklistExporter items={items} />
         <ChecklistImporter onImport={(imported) => setItems(imported)} />
       </div>

--- a/src/components/ChecklistExporter.tsx
+++ b/src/components/ChecklistExporter.tsx
@@ -9,10 +9,10 @@ interface Props {
 export default function ChecklistExporter({ items }: Props) {
   const handleExportCSV = () => {
     const csvContent = items
-      .map(item => `"${item.text}",${item.isChecked ? "完了" : "未完了"}`)
+      .map(item => `"${item.text}",${item.isChecked ? "完了" : "未完了"},${item.isProcured ? "調達済み" : "未調達"}`)
       .join("\n")
 
-    const csvHeader = `"項目名","状態"\n`
+    const csvHeader = `"項目名","状態","調達状況"\n`
     const blob = new Blob([csvHeader + csvContent], { type: "text/csv;charset=utf-8;" })
 
     const url = URL.createObjectURL(blob)
@@ -27,9 +27,10 @@ export default function ChecklistExporter({ items }: Props) {
   return (
     <button
       onClick={handleExportCSV}
-      className="mt-4 rounded-lg bg-dango-green-500 px-4 py-2 text-white shadow hover:bg-dango-green-600 transition"
+      className="flex-1 h-16 px-4 py-3 rounded-lg bg-dango-green-500 text-white shadow hover:bg-dango-green-600 transition flex flex-col items-center justify-center text-sm"
     >
-      端末に保存（CSV形式）
+      <span>端末に保存</span>
+      <span>（CSV形式）</span>
     </button>
   )
 }

--- a/src/components/ChecklistImporter.tsx
+++ b/src/components/ChecklistImporter.tsx
@@ -24,16 +24,21 @@ export default function ChecklistImporter({ onImport }: Props) {
       const dataLines = lines.slice(1)
 
       const importedItems: Item[] = dataLines.map((line, index) => {
-        // 「"タスク名",完了」or 「"タスク名",未完了」
-        const [rawText, status] = line.split(",")
+        // CSV行をパース（カンマで分割、引用符を考慮）
+        const columns = line.split(",")
 
         // " で囲まれているので除去
-        const text = rawText?.replace(/^"|"$/g, "") || ""
+        const text = columns[0]?.replace(/^"|"$/g, "") || ""
+        const status = columns[1]?.trim()
+        const procuredStatus = columns[2]?.trim()
 
         return {
           id: Date.now().toString() + index, // 新しいユニークIDを割り振る
           text,
-          isChecked: status?.trim() === "完了",
+          isChecked: status === "完了",
+          // 3列目がない場合（2列構成）は「カバンに入れた」のみに反映
+          // 3列目がある場合は調達状況を反映
+          isProcured: procuredStatus ? procuredStatus === "調達済み" : false,
         }
       })
 
@@ -46,10 +51,10 @@ export default function ChecklistImporter({ onImport }: Props) {
     <>
       <button
         onClick={() => fileInputRef.current?.click()}
-        className="px-4 py-2 rounded-lg bg-dango-green-500 text-white shadow hover:bg-dango-green-600 transition"
-        
+        className="flex-1 h-16 px-4 py-3 rounded-lg bg-dango-green-500 text-white shadow hover:bg-dango-green-600 transition flex flex-col items-center justify-center text-sm"
       >
-        リストを読み込み（CSV形式）
+        <span>リストを読み込み</span>
+        <span>（CSV形式）</span>
       </button>
       <input
         type="file"

--- a/src/components/ChecklistItem.tsx
+++ b/src/components/ChecklistItem.tsx
@@ -8,9 +8,11 @@ type Props = {
   onToggle: (id: string) => void
   onDelete: (id: string) => void
   onUpdate: (id: string, newText: string) => void
+  onToggleProcured?: (id: string) => void
+  twoStageMode?: boolean
 }
 
-export default function ChecklistItem({ item, onToggle, onDelete, onUpdate }: Props) {
+export default function ChecklistItem({ item, onToggle, onDelete, onUpdate, onToggleProcured, twoStageMode }: Props) {
   const [isEditing, setIsEditing] = useState(false)
   const [editText, setEditText] = useState(item.text)
 
@@ -49,36 +51,89 @@ export default function ChecklistItem({ item, onToggle, onDelete, onUpdate }: Pr
         }`}
     >
       <div className="flex items-center gap-4">
-        {/* チェックボックス */}
-        <div className="relative">
-          <input
-            type="checkbox"
-            id={item.id}
-            checked={item.isChecked}
-            onChange={() => onToggle(item.id)}
-            className="sr-only"
-          />
-          <label
-            htmlFor={item.id}
-            className={`flex items-center justify-center w-6 h-6 rounded-md border cursor-pointer
-              ${item.isChecked
-                ? "bg-dango-green-400 border-dango-green-500"
-                : "bg-white border-gray-300 group-hover:border-dango-pink-300"
-              }`}
-          >
-            {item.isChecked && (
-              <svg
-                className="w-4 h-4 text-white"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
+        {/* 二段階チェックボックス */}
+        {twoStageMode && onToggleProcured && (
+          <div className="flex gap-2">
+            {/* 調達チェック */}
+            <div className="relative">
+              <input
+                type="checkbox"
+                id={`${item.id}-procured`}
+                checked={item.isProcured || false}
+                onChange={() => onToggleProcured(item.id)}
+                className="sr-only"
+              />
+              <label
+                htmlFor={`${item.id}-procured`}
+                className={`flex items-center justify-center w-6 h-6 rounded-md border cursor-pointer
+                  ${item.isProcured
+                    ? "bg-dango-pink-400 border-dango-pink-500"
+                    : "bg-white border-gray-300 group-hover:border-dango-pink-300"
+                  }`}
               >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
-            )}
-          </label>
-        </div>
+                {item.isProcured && (
+                  <span className="text-white text-xs">📦</span>
+                )}
+              </label>
+            </div>
+
+            {/* カバンチェック */}
+            <div className="relative">
+              <input
+                type="checkbox"
+                id={item.id}
+                checked={item.isChecked}
+                onChange={() => onToggle(item.id)}
+                className="sr-only"
+              />
+              <label
+                htmlFor={item.id}
+                className={`flex items-center justify-center w-6 h-6 rounded-md border cursor-pointer
+                  ${item.isChecked
+                    ? "bg-dango-green-400 border-dango-green-500"
+                    : "bg-white border-gray-300 group-hover:border-dango-pink-300"
+                  }`}
+              >
+                {item.isChecked && (
+                  <span className="text-white text-xs">🎒</span>
+                )}
+              </label>
+            </div>
+          </div>
+        )}
+
+        {/* 通常のチェックボックス */}
+        {!twoStageMode && (
+          <div className="relative">
+            <input
+              type="checkbox"
+              id={item.id}
+              checked={item.isChecked}
+              onChange={() => onToggle(item.id)}
+              className="sr-only"
+            />
+            <label
+              htmlFor={item.id}
+              className={`flex items-center justify-center w-6 h-6 rounded-md border cursor-pointer
+                ${item.isChecked
+                  ? "bg-dango-green-400 border-dango-green-500"
+                  : "bg-white border-gray-300 group-hover:border-dango-pink-300"
+                }`}
+            >
+              {item.isChecked && (
+                <svg
+                  className="w-4 h-4 text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </label>
+          </div>
+        )}
 
         {/* テキスト */}
         {isEditing ? (

--- a/src/components/items.ts
+++ b/src/components/items.ts
@@ -2,6 +2,7 @@ export interface Item {
   id: string
   text: string
   isChecked: boolean
+  isProcured?: boolean // 調達したかどうか（二段階チェックリスト用）
 }
 
 export interface Template {


### PR DESCRIPTION
- Itemインタフェースに調達状況（isProcured）フィールドを追加
- 二段階モード切り替えボタンをページ上部に実装
- 調達（📦）とカバン（🎒）の2段階チェック機能を追加
- スクロール追従ラベルで視認性を向上
- CSV エクスポート/インポートを3列対応に拡張
- 2列CSVインポート時は「カバンに入れた」のみ反映する仕様

🤖 Generated with [Claude Code](https://claude.ai/code)