### PR TITLE
二段階チェックリスト機能のラベル変更と依存関係ロジックを実装

### DIFF
--- a/src/components/Checklist.tsx
+++ b/src/components/Checklist.tsx
@@ -19,9 +19,16 @@ export default function Checklist() {
   // チェックボックスのON/OFF
   const toggleItem = (id: string) => {
     setItems(prev =>
-      prev.map(item =>
-        item.id === id ? { ...item, isChecked: !item.isChecked } : item
-      )
+      prev.map(item => {
+        if (item.id === id) {
+          // 二段階モードで家の中にない場合はチェックできない
+          if (twoStageMode && !item.isProcured) {
+            return item
+          }
+          return { ...item, isChecked: !item.isChecked }
+        }
+        return item
+      })
     )
   }
 
@@ -30,12 +37,21 @@ export default function Checklist() {
     setItems(prev => prev.filter(item => item.id !== id))
   }
 
-  // 調達チェックのON/OFF
+  // 家の中にあるチェックのON/OFF
   const toggleProcured = (id: string) => {
     setItems(prev =>
-      prev.map(item =>
-        item.id === id ? { ...item, isProcured: !item.isProcured } : item
-      )
+      prev.map(item => {
+        if (item.id === id) {
+          const newIsProcured = !item.isProcured
+          // 家の中にないとカバンチェックも外す
+          return {
+            ...item,
+            isProcured: newIsProcured,
+            isChecked: newIsProcured ? item.isChecked : false
+          }
+        }
+        return item
+      })
     )
   }
 
@@ -108,7 +124,7 @@ export default function Checklist() {
               : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
           }`}
         >
-          {twoStageMode ? '📦🎒 二段階チェックモード ON' : '二段階チェックモード OFF'}
+          {twoStageMode ? '🏠🎒 二段階チェックモード ON' : '二段階チェックモード OFF'}
         </button>
       </div>
 
@@ -117,12 +133,12 @@ export default function Checklist() {
         <div className="sticky top-0 z-10 bg-gray-100/95 backdrop-blur-sm border-b-2 border-gray-300/50 py-3 mb-4 shadow-sm">
           <div className="flex justify-center gap-8 text-sm font-semibold text-gray-800">
             <div className="flex items-center gap-1 px-3 py-1 bg-dango-pink-300 rounded-full">
-              <span>📦</span>
-              <span>調達</span>
+              <span>🏠</span>
+              <span>家の中にある</span>
             </div>
             <div className="flex items-center gap-1 px-3 py-1 bg-dango-green-300 rounded-full">
               <span>🎒</span>
-              <span>カバン</span>
+              <span>カバンに入れた</span>
             </div>
           </div>
         </div>

--- a/src/components/ChecklistItem.tsx
+++ b/src/components/ChecklistItem.tsx
@@ -54,7 +54,7 @@ export default function ChecklistItem({ item, onToggle, onDelete, onUpdate, onTo
         {/* 二段階チェックボックス */}
         {twoStageMode && onToggleProcured && (
           <div className="flex gap-2">
-            {/* 調達チェック */}
+            {/* 家の中にあるチェック */}
             <div className="relative">
               <input
                 type="checkbox"
@@ -72,26 +72,33 @@ export default function ChecklistItem({ item, onToggle, onDelete, onUpdate, onTo
                   }`}
               >
                 {item.isProcured && (
-                  <span className="text-white text-xs">📦</span>
+                  <span className="text-white text-xs">🏠</span>
                 )}
               </label>
             </div>
 
-            {/* カバンチェック */}
+            {/* カバンに入れたチェック */}
             <div className="relative">
               <input
                 type="checkbox"
                 id={item.id}
                 checked={item.isChecked}
                 onChange={() => onToggle(item.id)}
+                disabled={!item.isProcured}
                 className="sr-only"
               />
               <label
                 htmlFor={item.id}
-                className={`flex items-center justify-center w-6 h-6 rounded-md border cursor-pointer
+                className={`flex items-center justify-center w-6 h-6 rounded-md border
+                  ${!item.isProcured
+                    ? "cursor-not-allowed opacity-50 bg-gray-100 border-gray-200"
+                    : "cursor-pointer"
+                  }
                   ${item.isChecked
                     ? "bg-dango-green-400 border-dango-green-500"
-                    : "bg-white border-gray-300 group-hover:border-dango-pink-300"
+                    : item.isProcured
+                    ? "bg-white border-gray-300 group-hover:border-dango-pink-300"
+                    : "bg-gray-100 border-gray-200"
                   }`}
               >
                 {item.isChecked && (

--- a/src/components/items.ts
+++ b/src/components/items.ts
@@ -2,7 +2,7 @@ export interface Item {
   id: string
   text: string
   isChecked: boolean
-  isProcured?: boolean // 調達したかどうか（二段階チェックリスト用）
+  isProcured?: boolean // 家の中にあるかどうか（二段階チェックリスト用）
 }
 
 export interface Template {


### PR DESCRIPTION
- ラベルを「調達」「カバン」から「家の中にある」「カバンに入れた」に変更
- 「家の中にある」がチェックされていない場合、「カバンに入れた」にチェックできないロジックを追加
- 「家の中にある」のチェックを外すと「カバンに入れた」も自動的に外れる仕様を実装

🤖 Generated with [Claude Code](https://claude.ai/code)